### PR TITLE
fix: prevent fork PRs from triggering release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+    paths:
+      - 'package.json'
 
 env:
   NODE_VERSION: 24.x
@@ -14,7 +16,7 @@ permissions:
 jobs:
   build:
     name: Build
-    if: ${{ github.event.pull_request.merged }}
+    if: ${{ github.event.pull_request.merged && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
## Summary
- Add same-repo check to release pipeline: merged PRs from forks no longer trigger publishing
- Add missing `paths: ['package.json']` filter — previously release pipeline would trigger on ANY merged PR to main, not just version bumps

## Test plan
- [ ] Verify release still triggers on merged PR that modifies package.json
- [ ] Verify release does NOT trigger on a merged PR that only modifies other files
- [ ] Verify release does NOT trigger on merged fork PR